### PR TITLE
chore: restore .github workflows except README

### DIFF
--- a/.github/workflows/be-deploy.yml
+++ b/.github/workflows/be-deploy.yml
@@ -1,0 +1,67 @@
+name: 🐳 [BE] Build & Deploy
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - "engine/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🐳 Build apps
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    outputs:
+      pushout: ${{ github.run_number }}
+    env:
+      BASE_IMAGE: "ghcr.io/waffle-id/engine"
+    steps:
+    - name: ⬇️ Checkout repo
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      id: push
+      with:
+        context: ./engine
+        push: true
+        provenance: false
+        tags: ${{ env.BASE_IMAGE }}:latest,${{ env.BASE_IMAGE }}:${{ github.run_number }}
+
+  deploy-prod:
+    name: Engine to Production
+    if: |
+      success() &&
+      (github.ref == 'refs/heads/main') &&
+      (github.event_name != 'workflow_dispatch')
+    needs: [ build ]
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: "production"
+      environment-url: "https://waffle.food/"
+      nomad-directory: ".deployment/nomad"
+      nomad-job: "engine.hcl"
+      nomad-addr: "https://nomad.waffle.food"
+      image-tag: ${{ needs.build.outputs.pushout }}
+      module: "engine"
+      semver-type: minor
+    secrets: inherit

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,49 @@
+name: 🐳 [CONTRACTS] Integration
+
+on:
+  push:
+    paths:
+    - "contracts/**"
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+      matrix:
+        version: [ 1 ]
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+
+    - name: Install Deps
+      run: |
+        forge install https://github.com/foundry-rs/forge-std https://github.com/OpenZeppelin/openzeppelin-contracts
+
+    - name: Show Forge version
+      run: |
+        forge --version
+
+    - name: Run Forge fmt
+      run: |
+        forge fmt --check
+      id: fmt
+
+    - name: Run Forge build
+      run: |
+        forge build --sizes
+      id: build
+
+    - name: Run Forge tests
+      run: |
+        forge test -vvv
+      id: test

--- a/.github/workflows/fe-deploy.yml
+++ b/.github/workflows/fe-deploy.yml
@@ -1,0 +1,67 @@
+name: 🐳 [FE] Build & Deploy
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - "web/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🐳 Build apps
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    outputs:
+      pushout: ${{ github.run_number }}
+    env:
+      BASE_IMAGE: "ghcr.io/waffle-id/web"
+    steps:
+    - name: ⬇️ Checkout repo
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      id: push
+      with:
+        context: ./web
+        push: true
+        provenance: false
+        tags: ${{ env.BASE_IMAGE }}:latest,${{ env.BASE_IMAGE }}:${{ github.run_number }}
+
+  deploy-prod:
+    name: Web to Production
+    if: |
+      success() &&
+      (github.ref == 'refs/heads/main') &&
+      (github.event_name != 'workflow_dispatch')
+    needs: [ build ]
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: "production"
+      environment-url: "https://waffle.food/"
+      nomad-directory: ".deployment/nomad"
+      nomad-job: "web.hcl"
+      nomad-addr: "https://nomad.waffle.food"
+      image-tag: ${{ needs.build.outputs.pushout }}
+      module: "web"
+      semver-type: minor
+    secrets: inherit

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1,0 +1,107 @@
+name: Reusable Deployment
+
+on:
+  workflow_call:
+    inputs:
+      nomad-directory:
+        description: "Nomad directory of the job."
+        required: true
+        type: string
+      nomad-job:
+        description: "Nomad Job HCL file"
+        required: true
+        type: string
+      nomad-addr:
+        description: "Nomad Address"
+        required: true
+        type: string
+      image-tag:
+        description: "The docker image tag"
+        required: true
+        type: string
+      environment:
+        description: "The deployment environment."
+        required: true
+        type: string
+      environment-url:
+        description: "The URL of the deployment environment."
+        required: true
+        type: string
+      module:
+        description: "Which module"
+        required: true
+        type: string
+      semver-type:
+        description: "Semantic versioning type (major/minor/patch). Defaults to 'patch'."
+        default: "patch"
+        required: false
+        type: string
+jobs:
+  deploy:
+    name: Deploy to Nomad
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.module }}
+      cancel-in-progress: true
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Show GitHub contexts
+      env:
+        GITHUB_CONTEXT_JSON: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT_JSON"
+
+    - name: Show Workflow Inputs contexts
+      env:
+        WORKFLOW_INPUTS_CONTEXT_JSON: ${{ toJson(inputs) }}
+      run: |
+        echo "$WORKFLOW_INPUTS_CONTEXT_JSON"
+
+    - name: Search and replace value in Nomad Config
+      run: |
+        sed -i "s|place_image_sha|${{ inputs.image-tag }}|g" ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }}
+        sed -i "s|ghcr_password|${{ secrets.GH_TOKEN }}|g" ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }}
+        sed -i "s|mode_env|${{ inputs.environment }}|g" ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }}
+
+    - name: Backend Config Nomad
+      if: inputs.module == 'engine'
+      run: |
+        sed -i "s|place_mongo_uri|${{ secrets.MONGO_URI }}|g" ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }}
+
+    - name: Frontend Config Nomad
+      if: inputs.module == 'web'
+      run: |
+        sed -i "s|place_client_id|${{ secrets.CLIENT_ID }}|g" ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }}
+        sed -i "s|place_client_secret|${{ secrets.CLIENT_SECRET }}|g" ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }}
+
+    - name: Nomad parse .hcl to .json
+      id: job-parse
+      run: |
+        jq -Rsc '{ JobHCL: ., Canonicalize: true }' ${{ inputs.nomad-directory }}/${{ inputs.nomad-job }} > payload.json;
+        parsed=$(curl -H "CF-Access-Client-Id: ${{ secrets.CF_Access_Client_Id }}" -H "CF-Access-Client-Secret: ${{ secrets.CF_Access_Client_Secret }}" -d @payload.json -X POST ${{ inputs.nomad-addr }}/v1/jobs/parse);
+        echo "parsed=$parsed" >> $GITHUB_OUTPUT
+
+    - name: Nomad deployment
+      run: |
+        response=$(curl -s -o response.json -w "%{http_code}" \
+          -H "CF-Access-Client-Id: ${{ secrets.CF_Access_Client_Id }}" \
+          -H "CF-Access-Client-Secret: ${{ secrets.CF_Access_Client_Secret }}" \
+          -X POST \
+          -d '{ "job": ${{ steps.job-parse.outputs.parsed }} }' \
+          ${{ inputs.nomad-addr }}/v1/jobs)
+
+        echo "Nomad response status: $response"
+        cat response.json
+
+        if [ "$response" -ne 200 ]; then
+          echo "❌ Nomad deployment failed with status $response"
+          exit 1
+        else
+          echo "✅ Nomad deployment succeeded"
+        fi

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,0 +1,67 @@
+name: 🐳 [SCRAPER] Build & Deploy
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - "scraper/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🐳 Build apps
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    outputs:
+      pushout: ${{ github.run_number }}
+    env:
+      BASE_IMAGE: "ghcr.io/waffle-id/scraper"
+    steps:
+    - name: ⬇️ Checkout repo
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      id: push
+      with:
+        context: ./scraper
+        push: true
+        provenance: false
+        tags: ${{ env.BASE_IMAGE }}:latest,${{ env.BASE_IMAGE }}:${{ github.run_number }}
+
+  deploy-prod:
+    name: Scraper to Production
+    if: |
+      success() &&
+      (github.ref == 'refs/heads/main') &&
+      (github.event_name != 'workflow_dispatch')
+    needs: [ build ]
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: "production"
+      environment-url: "https://waffle.food/"
+      nomad-directory: ".deployment/nomad"
+      nomad-job: "scraper.hcl"
+      nomad-addr: "https://nomad.waffle.food"
+      image-tag: ${{ needs.build.outputs.pushout }}
+      module: "scraper"
+      semver-type: minor
+    secrets: inherit


### PR DESCRIPTION
This pull request introduces several GitHub Actions workflows for building, testing, and deploying various components of the project. It also includes a reusable workflow for Nomad-based deployments. These changes aim to streamline CI/CD processes across the backend, frontend, scraper, and smart contract modules.

### New Workflows for CI/CD:

* **Backend Build & Deploy Workflow**: Added `.github/workflows/be-deploy.yml` to build and deploy the backend (`engine`) module using Docker and Nomad. Includes steps for Docker image creation, pushing to the GitHub Container Registry, and deploying to production.
* **Frontend Build & Deploy Workflow**: Added `.github/workflows/fe-deploy.yml` to build and deploy the frontend (`web`) module with similar steps as the backend workflow.
* **Scraper Build & Deploy Workflow**: Added `.github/workflows/scraper.yml` to handle CI/CD for the scraper module, following the same pattern as the backend and frontend workflows.

### Workflow for Smart Contract Integration:

* **Contracts Integration Workflow**: Added `.github/workflows/contracts.yml` to manage smart contract development using Foundry. Includes steps for dependency installation, formatting, building, and running tests.

### Reusable Deployment Workflow:

* **Reusable Nomad Deployment Workflow**: Added `.github/workflows/reusable-deploy.yml` to standardize the deployment process for modules using Nomad. It supports dynamic configuration for Nomad jobs and environment-specific settings.